### PR TITLE
make compile on Scintific Linux 6.5

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS = -I m4
+
 if ENABLE_TESTS
   MAYBE_TEST = test
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,7 @@ psftest_LDFLAGS = libpsf.la
 libpsf_la_SOURCES = psf.cc psfdata.cc psfproperty.cc psfchunk.cc \
 	psfcontainer.cc psfindexedcontainer.cc psfgroup.cc psffile.cc \
 	psftype.cc psfstruct.cc psfsections.cc psftrace.cc \
-	psfnonsweepvalue.cc psfsweepvalue.cc
+	psfnonsweepvalue.cc psfsweepvalue.cc psfpropertyblock.cc
 
 libpsf_la_CXXFLAGS = \
 	-I../include ${BOOST_CPPFLAGS}


### PR DESCRIPTION
Needed to add this to make it compile on Scintific Linux 6.5, otherwise the AX_BOOST_MACRO in configure.ac was not recogniced. Also a source file was missing in Makefile.am.
