### PR TITLE
Remove writes to standard error

### DIFF
--- a/src/psf.cc
+++ b/src/psf.cc
@@ -123,7 +123,6 @@ bool PSFDataSet::get_invertstruct() const {
 
 inline void PSFDataSet::verify_open() const {
     if (!m_is_open) {
-	std::cerr << "Data set is not open" << std::endl;
 	throw DataSetNotOpen();
     }
 }

--- a/src/psfnonsweepvalue.cc
+++ b/src/psfnonsweepvalue.cc
@@ -9,7 +9,6 @@ Chunk * ValueSectionNonSweep::child_factory(int chunktype) const {
     if(NonSweepValue::ischunk(chunktype))
 	return new NonSweepValue(psf);
     else {
-	std::cerr << "Unexpected chunktype: " << chunktype << std::endl;
 	throw IncorrectChunk(chunktype);
     }
 }

--- a/src/psfreader.cc
+++ b/src/psfreader.cc
@@ -9,7 +9,6 @@ Chunk * ValueSectionNonSweep::child_factory(int chunktype) {
     if(NonSweepValue::ischunk(chunktype))
 	return new NonSweepValue(psf);
     else {
-	std::cerr << "Unexpected chunktype: " << chunktype << std::endl;
 	throw IncorrectChunk(chunktype);
     }
 }

--- a/src/psfsections.cc
+++ b/src/psfsections.cc
@@ -8,7 +8,6 @@ Chunk *HeaderSection::child_factory(int chunktype) const {
     else if(chunktype == 1)
 	return NULL;
     else {
-	std::cerr << "Unexpected chunktype: " << chunktype << std::endl;
 	throw IncorrectChunk(chunktype);
     }
 }
@@ -28,7 +27,6 @@ Chunk *TypeSection::child_factory(int chunktype) const {
     if(DataTypeDef::ischunk(chunktype))
 	return new DataTypeDef();
     else {
-	std::cerr << "Unexpected chunktype: " << chunktype << std::endl;
 	throw IncorrectChunk(chunktype);
     }
 }
@@ -39,7 +37,6 @@ Chunk * SweepSection::child_factory(int chunktype) const {
     else if(chunktype == 3)
 	return NULL;
     else {
-	std::cerr << "Unexpected chunktype: " << chunktype << std::endl;
 	throw IncorrectChunk(chunktype);
     }
 }

--- a/src/psftrace.cc
+++ b/src/psftrace.cc
@@ -8,7 +8,6 @@ Chunk * TraceSection::child_factory(int chunktype) const {
     else if(GroupDef::ischunk(chunktype))
 	return new GroupDef(psf);
     else {
-	std::cerr << "Unexpected chunktype: " << chunktype << std::endl;
 	throw IncorrectChunk(chunktype);
     }
 }


### PR DESCRIPTION
Hi, I removed the writes to std::cerr that precede raising exceptions (it pollutes the output). Let me know what you think.